### PR TITLE
Editor's focusHighlightForeground now bit darker

### DIFF
--- a/themes/Brackets Light Pro-color-theme.json
+++ b/themes/Brackets Light Pro-color-theme.json
@@ -4,7 +4,7 @@
     "editor.background": "#f8f8f8",
     "editorCursor.foreground": "#000000",
     "editor.foreground": "#353535",
-    "editor.lineHighlightBackground": "#f8f8f8",
+    "editor.lineHighlightBackground": "#f0f0f0",
     "editor.selectionBackground": "#abdffa",
     "activityBar.background": "#c3c7cd",
     "activityBar.foreground": "#000000",
@@ -21,6 +21,7 @@
     "editorIndentGuide.background": "#eaeaea",
     "editorSuggestWidget.selectedBackground": "#dbdde0",
     "editorSuggestWidget.selectedForeground": "#101c32",
+	"editorSuggestWidget.focusHighlightForeground": "#386ac3",
     "quickInputList.focusBackground": "#dbdde0",
     "quickInputList.focusForeground": "#101c32"
   },


### PR DESCRIPTION
This chagne will help to see foucsed highlighted color clearly in light background. In this way we don't need to add anything additonal to settings.json file.

### After this change:

![Screenshot (5)](https://user-images.githubusercontent.com/19422792/202523692-31d8dc86-83b0-45c7-bfb0-b4614ff84ea3.png)
